### PR TITLE
重新打包AppImage版本QQ

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,49 @@
+name: Install and Test LL on Linux
+
+on:
+  push:
+    paths:
+      - 'repack_appimage.sh'
+  workflow_dispatch:
+
+jobs:
+  install_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 libfuse2
+
+    - name: Download QQ Software
+      run: |
+        wget https://dldir1.qq.com/qqfile/qq/QQNT/852276c1/linuxqq_3.2.5-21453_x86_64.AppImage
+        mv linuxqq_3.2.5-21453_x86_64.AppImage QQ.AppImage
+        wget --no-check-certificate --content-disposition https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
+
+    - name: Run repack_appimage.sh
+      run: |
+        chmod +x repack_appimage.sh
+        ./repack_appimage.sh
+
+    - name: Check output and directory existence
+      run: |
+        if ! /opt/QQ/qq --logging-enable | grep -q "[LiteLoader]" || [ ! -d "/opt/LiteLoader/plugins" ]; then
+          echo "LiteLoader not found in output or /opt/LiteLoader/plugins directory does not exist. Test failed."
+          exit 1
+        else
+          echo "LiteLoader found in output and /opt/LiteLoader/plugins directory exists. Test succeeded."
+        fi
+
+    - name: Check LiteLoader Store
+      run: |
+        # 检查 LiteLoader 插件是否存在
+        if [ -d "/opt/LiteLoader/plugins/pluginStore" ]; then
+          echo "LiteLoader pluginStore folder exists. Test succeeded."
+        else
+          echo "LiteLoader pluginStore folder does not exist. Test failed."
+          exit 1
+        fi
+

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -22,6 +22,7 @@ jobs:
         wget https://dldir1.qq.com/qqfile/qq/QQNT/852276c1/linuxqq_3.2.5-21453_x86_64.AppImage
         mv linuxqq_3.2.5-21453_x86_64.AppImage QQ.AppImage
         wget --no-check-certificate --content-disposition https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
+        chmod +x appimagetool-x86_64.AppImage
 
     - name: Run repack_appimage.sh
       run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -17,6 +17,9 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 squashfs-tools
 
+    - name: Set fuse
+      run: sudo apt install -y fuse2
+
     - name: Download QQ Software
       run: |
         wget https://dldir1.qq.com/qqfile/qq/QQNT/852276c1/linuxqq_3.2.5-21453_x86_64.AppImage

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,10 +1,9 @@
-name: Install and Test LL on Linux
+name: Create and Test AppImage
 
 on:
   push:
     paths:
       - 'repack_appimage.sh'
-      - '.github/workflows/appimage.yml'
   workflow_dispatch:
 
 jobs:
@@ -16,10 +15,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 squashfs-tools
-
-    - name: Set fuse
-      run: sudo apt install -y libfuse2
+      run: sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 squashfs-tools libfuse2
 
     - name: Download QQ Software
       run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -15,37 +15,25 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install dependencies
-      run: sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 libfuse2
+      run: sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 squashfs-tools
 
     - name: Download QQ Software
       run: |
         wget https://dldir1.qq.com/qqfile/qq/QQNT/852276c1/linuxqq_3.2.5-21453_x86_64.AppImage
-        mv linuxqq_3.2.5-21453_x86_64.AppImage QQ.AppImage
-        wget --no-check-certificate --content-disposition https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
-        chmod +x appimagetool-x86_64.AppImage
+        mv linuxqq_3.2.5-21453_x86_64.AppImage QQ.AppImage.old
+        wget --no-check-certificate --content-disposition https://github.com/AppImage/AppImageKit/releases/download/13/runtime-x86_64
 
     - name: Run repack_appimage.sh
       run: |
         chmod +x repack_appimage.sh
         ./repack_appimage.sh
-        ls
 
     - name: Check output and directory existence
       run: |
-        if ! /opt/QQ/qq --logging-enable | grep -q "[LiteLoader]" || [ ! -d "/opt/LiteLoader/plugins" ]; then
+        if ! ./QQ.AppImage --logging-enable | grep -q "[LiteLoader]" || [ ! -d "$HOME/.config/QQ/LiteLoader/plugins" ]; then
           echo "LiteLoader not found in output or /opt/LiteLoader/plugins directory does not exist. Test failed."
           exit 1
         else
           echo "LiteLoader found in output and /opt/LiteLoader/plugins directory exists. Test succeeded."
-        fi
-
-    - name: Check LiteLoader Store
-      run: |
-        # 检查 LiteLoader 插件是否存在
-        if [ -d "/opt/LiteLoader/plugins/pluginStore" ]; then
-          echo "LiteLoader pluginStore folder exists. Test succeeded."
-        else
-          echo "LiteLoader pluginStore folder does not exist. Test failed."
-          exit 1
         fi
 

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -19,8 +19,8 @@ jobs:
 
     - name: Download QQ Software
       run: |
-        wget https://dldir1.qq.com/qqfile/qq/QQNT/852276c1/linuxqq_3.2.5-21453_x86_64.AppImage
-        mv linuxqq_3.2.5-21453_x86_64.AppImage QQ.AppImage.old
+        wget https://dldir1.qq.com/qqfile/qq/QQNT/Linux/QQ_3.2.6_240322_x86_64_01.AppImage
+        mv QQ_3.2.6_240322_x86_64_01.AppImage QQ.AppImage.old
         wget --no-check-certificate --content-disposition https://github.com/AppImage/AppImageKit/releases/download/13/runtime-x86_64
 
     - name: Run repack_appimage.sh

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - 'repack_appimage.sh'
+      - '.github/workflows/appimage.yml'
   workflow_dispatch:
 
 jobs:
@@ -18,7 +19,7 @@ jobs:
       run: sudo apt-get install -y libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 xdg-utils libatspi2.0-0 libuuid1 libsecret-1-0 squashfs-tools
 
     - name: Set fuse
-      run: sudo apt install -y fuse2
+      run: sudo apt install -y libfuse2
 
     - name: Download QQ Software
       run: |

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         chmod +x repack_appimage.sh
         ./repack_appimage.sh
+        ls
 
     - name: Check output and directory existence
       run: |

--- a/repack_appimage.sh
+++ b/repack_appimage.sh
@@ -28,17 +28,6 @@ git clone https://github.com/LiteLoaderQQNT/LiteLoaderQQNT.git LiteLoader
 echo "拉取完成，正在安装LiteLoader..."
 cp -f LiteLoader/src/preload.js $target_dir/resources/app/application/preload.js
 
-tmp_bak_dir="/tmp/LiteLoader_bak"
-# 如果目标目录存在且不为空，则先备份处理
-if [ -e "$install_dir/LiteLoader" ]; then
-    # 删除上次的备份
-    rm -rf "$tmp_bak_dir"
-
-    # 将已存在的目录重命名为LiteLoader_bak
-    mv "$install_dir/LiteLoader" $tmp_bak_dir
-    echo "已将原LiteLoader目录暂时移动为LiteLoader_bak"
-fi
-
 # 移动LiteLoader
 mv -f LiteLoader "$install_dir/LiteLoader"
 
@@ -72,7 +61,6 @@ echo "安装完成！脚本将自动退出..."
 # 清理临时文件
 rm -rf /tmp/LiteLoader
 rm -rf tmp.squashfs
-rm -rf $tmp_bak_dir
 if [ "$GITHUB_ACTIONS" == "true" ]; then
     echo "Do not clear $target_dir"
 else

--- a/repack_appimage.sh
+++ b/repack_appimage.sh
@@ -1,14 +1,14 @@
 
-echo "标记可执行"
+echo "处理原AppImage"
 chmod +x QQ.AppImage.old
-echo "自解压"
 ./QQ.AppImage.old --appimage-extract >/dev/null
+
 cd squashfs-root
 target_dir=$PWD
 install_dir="$target_dir/resources/app/app_launcher"
 config_file="$target_dir/AppRun"
-plugin_dir="\$HOME/.config/QQ/LiteLoader/plugins"
-echo "当前关键变量 target_dir:$target_dir"
+plugin_dir="\$HOME/.config/QQ/LiteLoader"
+echo "当前target_dir:$target_dir"
 
 # 检查是否已存在LITELOADERQQNT_PROFILE
 if grep -q "export LITELOADERQQNT_PROFILE=" "$config_file"; then
@@ -19,8 +19,8 @@ else
     echo "已添加 LITELOADERQQNT_PROFILE: $plugin_dir"
 fi
 
-echo "正在拉取最新版本的仓库..."
 cd /tmp
+echo "正在拉取最新版本的仓库..."
 rm -rf LiteLoader
 git clone https://github.com/LiteLoaderQQNT/LiteLoaderQQNT.git LiteLoader
 
@@ -51,21 +51,18 @@ fi
 chmod -R 0777 $install_dir
 
 cd "$target_dir/.."
+echo "正在重打包"
 mksquashfs squashfs-root tmp.squashfs -root-owned -noappend
 cat runtime-x86_64 >> QQ.AppImage
 cat tmp.squashfs >> QQ.AppImage
 chmod a+x QQ.AppImage
+echo "注意，插件与配置文件将放在 $plugin_dir"
 
-echo "安装完成！脚本将自动退出..."
-
+echo "清理临时文件"
 # 清理临时文件
 rm -rf /tmp/LiteLoader
 rm -rf tmp.squashfs
-if [ "$GITHUB_ACTIONS" == "true" ]; then
-    echo "Do not clear $target_dir"
-else
-    rm -r $target_dir
-fi
+rm -r $target_dir
 
 # 错误处理.
 if [ $? -ne 0 ]; then

--- a/repack_appimage.sh
+++ b/repack_appimage.sh
@@ -75,7 +75,7 @@ fi
 chmod -R 0777 $install_dir
 
 cd "$target_dir/.."
-./appimagetool-x86_64.AppImage -vgn $target_dir
+ARCH=x86_64 ./appimagetool-x86_64.AppImage -vgn $target_dir
 
 echo "安装完成！脚本将自动退出..."
 

--- a/repack_appimage.sh
+++ b/repack_appimage.sh
@@ -88,7 +88,7 @@ else
     rm -r $target_dir
 fi
 
-# 错误处理
+# 错误处理.
 if [ $? -ne 0 ]; then
     echo "发生错误，安装失败"
     exit 1

--- a/repack_appimage.sh
+++ b/repack_appimage.sh
@@ -52,7 +52,7 @@ chmod -R 0777 $install_dir
 
 cd "$target_dir/.."
 echo "正在重打包"
-mksquashfs squashfs-root tmp.squashfs -root-owned -noappend
+mksquashfs squashfs-root tmp.squashfs -root-owned -noappend >/dev/null
 cat runtime-x86_64 >> QQ.AppImage
 cat tmp.squashfs >> QQ.AppImage
 chmod a+x QQ.AppImage

--- a/repack_appimage.sh
+++ b/repack_appimage.sh
@@ -75,6 +75,10 @@ fi
 chmod -R 0777 $install_dir
 
 cd "$target_dir/.."
+mkdir /opt/QQ
+mkdir /opt/QQ/resources
+mkdir /opt/QQ/resources/app
+touch /opt/QQ/resources/app/512x512.png
 ARCH=x86_64 ./appimagetool-x86_64.AppImage -vgn $target_dir
 
 echo "安装完成！脚本将自动退出..."

--- a/repack_appimage.sh
+++ b/repack_appimage.sh
@@ -77,7 +77,7 @@ chmod -R 0777 $install_dir
 cd "$target_dir/.."
 ./appimagetool-x86_64.AppImage -vgn $target_dir
 
-echo "安装完成！脚本将在3秒后退出..."
+echo "安装完成！脚本将自动退出..."
 
 # 清理临时文件
 rm -rf /tmp/LiteLoader

--- a/repack_appimage.sh
+++ b/repack_appimage.sh
@@ -1,0 +1,97 @@
+
+echo "标记可执行"
+chmod +x QQ.AppImage
+echo "自解压"
+./QQ.AppImage --appimage-extract >/dev/null
+cd squashfs-root
+target_dir=$PWD
+install_dir="$target_dir/resources/app/app_launcher"
+config_file="$target_dir/AppRun"
+echo "当前关键变量 target_dir:$target_dir"
+
+# 检查是否已存在LITELOADERQQNT_PROFILE
+if grep -q "export LITELOADERQQNT_PROFILE=" "$config_file"; then
+    sed -i 's|export LITELOADERQQNT_PROFILE=.*|export LITELOADERQQNT_PROFILE="'$install_dir/LiteLoader/plugins'"|' "$config_file"
+else
+    # 如果不存在，则添加新的行
+    echo 'export LITELOADERQQNT_PROFILE="'$install_dir/LiteLoader/plugins'"' >> "$config_file"
+    echo "已添加 LITELOADERQQNT_PROFILE: $install_dir/LiteLoader/plugins"
+fi
+
+echo "正在拉取最新版本的仓库..."
+cd /tmp
+rm -rf LiteLoader
+git clone https://github.com/LiteLoaderQQNT/LiteLoaderQQNT.git LiteLoader
+
+# 移动到安装目录
+echo "拉取完成，正在安装LiteLoader..."
+cp -f LiteLoader/src/preload.js $target_dir/resources/app/application/preload.js
+
+tmp_bak_dir="/tmp/LiteLoader_bak"
+# 如果目标目录存在且不为空，则先备份处理
+if [ -e "$install_dir/LiteLoader" ]; then
+    # 删除上次的备份
+    rm -rf "$tmp_bak_dir"
+
+    # 将已存在的目录重命名为LiteLoader_bak
+    mv "$install_dir/LiteLoader" $tmp_bak_dir
+    echo "已将原LiteLoader目录暂时移动为LiteLoader_bak"
+fi
+
+# 移动LiteLoader
+mv -f LiteLoader "$install_dir/LiteLoader"
+
+# 如果LiteLoader_bak中存在plugins文件夹，则复制到新的LiteLoader目录
+if [ -d "$tmp_bak_dir/plugins" ]; then
+    cp -r "$tmp_bak_dir/plugins" "$install_dir/LiteLoader/plugins"
+    echo "已将 LiteLoader_bak 中旧数据复制到新的 LiteLoader 目录"
+    cp "$tmp_bak_dir/config.json" "$install_dir/LiteLoader/plugins"
+    echo "已将 LiteLoader_bak 中旧 config.json 复制到新的 LiteLoader 目录"
+fi
+
+# 如果LiteLoader_bak中存在data文件夹，则复制到新的LiteLoader目录
+if [ -d "$tmp_bak_dir/data" ]; then
+    cp -r "$tmp_bak_dir/data" "$install_dir/LiteLoader/"
+    echo "已将 LiteLoader_bak 中旧数据复制到新的 LiteLoader 目录"
+fi
+
+# 进入安装目录
+cd "$install_dir"
+
+# 修改index.js
+echo "正在修补index.js...$PWD"
+
+# 检查是否已存在相同的修改
+if grep -q "require('./LiteLoader');" index.js; then
+    echo "index.js 已包含相同的修改，无需再次修改。"
+else
+    # 如果不存在，则进行修改
+    sed -i '' -e "1i\\
+require('./LiteLoader');\
+" -e '$a\' index.js
+    echo "已修补 index.js。"
+fi
+
+chmod -R 0777 $install_dir
+
+cd "$target_dir/.."
+./appimagetool-x86_64.AppImage -vgn $target_dir
+
+echo "安装完成！脚本将在3秒后退出..."
+
+# 清理临时文件
+rm -rf /tmp/LiteLoader
+rm -rf $tmp_bak_dir
+if [ "$GITHUB_ACTIONS" == "true" ]; then
+    echo "Do not clear $target_dir"
+else
+    rm -r $target_dir
+fi
+
+# 错误处理
+if [ $? -ne 0 ]; then
+    echo "发生错误，安装失败"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
重新打包AppImage以安装LiteLoaderQQNT，本地测试通过

配置文件默认放在 `~/.config/QQ/LiteLoader` 下，可通过修改脚本内 `plugin_dir` 改变目标位置

没有实现插件商店的安装

建议合并为一个commit，~~因为调试Action真的麻烦~~