### PR TITLE
Bug fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,6 @@ github_download_proxies=(
     "https://gh.h233.eu.org"
     "https://gh.ddlc.top"
     "https://slink.ltd"
-    "https://gh.con.sh"
     "https://cors.isteed.cc"
     "https://hub.gitmirror.com"
     "https://sciproxy.com"

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,22 @@ function elevate_permissions() {
             log_info "请输入您的密码以提升权限："
             sudo -v || { log_error "提权失败，请重试或添加 '-k' 参数以跳过提权，退出"; return 1; }
             sudo_cmd="sudo" ;;
-        macos)  sudo_cmd="" ;;
+        macos)  
+            # 检测是否有完全磁盘访问权限
+            testfile="/Applications/test_permission_file"
+            if touch "$testfile" 2>/dev/null; then
+              log_info "终端具有对 /Applications 的管理权限。"
+              log_info "无需额外申请 sudo 权限"
+              rm "$testfile"
+              sudo_cmd="" 
+
+            else
+              log_info "终端没有对 /Applications 的管理权限。"
+              log_info "推荐赋予终端 完全磁盘访问权限 App管理权限。"
+              log_info "接下来将使用sudo 提权"
+              sudo -v || { log_error "提权失败，请重试或添加 '-k' 参数以跳过提权，退出"; return 1; }
+              sudo_cmd="sudo" 
+            fi;;
     esac
 }
 

--- a/install.sh
+++ b/install.sh
@@ -86,22 +86,7 @@ function elevate_permissions() {
             log_info "请输入您的密码以提升权限："
             sudo -v || { log_error "提权失败，请重试或添加 '-k' 参数以跳过提权，退出"; return 1; }
             sudo_cmd="sudo" ;;
-        macos)  
-            # 检测是否有完全磁盘访问权限
-            testfile="/Applications/test_permission_file"
-            if touch "$testfile" 2>/dev/null; then
-              log_info "终端具有对 /Applications 的管理权限。"
-              log_info "无需额外申请 sudo 权限"
-              rm "$testfile"
-              sudo_cmd="" 
-
-            else
-              log_info "终端没有对 /Applications 的管理权限。"
-              log_info "推荐赋予终端 完全磁盘访问权限 App管理权限。"
-              log_info "接下来将使用sudo 提权"
-              sudo -v || { log_error "提权失败，请重试或添加 '-k' 参数以跳过提权，退出"; return 1; }
-              sudo_cmd="sudo" 
-            fi;;
+        macos)  sudo_cmd="" ;;
     esac
 }
 
@@ -376,7 +361,7 @@ function patch_resources() {
 
     # 写入 require(String.raw`*`) 到 *.js 文件
     log_info "正在创建/覆写文件：'$jsfile_path'"
-    echo "require(\"${ll_path%/}\");" | $sudo_cmd tee "$jsfile_path" > /dev/null
+    echo "require(\"${ll_path%/}\");" | sudo tee "$jsfile_path" > /dev/null
     log_info "写入成功：'require(\"${ll_path%/}\");'"
 
     # 检查 package.json 文件是否存在
@@ -386,7 +371,7 @@ function patch_resources() {
     # 修改 package.json 中的 main 字段为 ./app_launcher/launcher.js
     log_info "正在修改文件：$package_json"
     _tmp="$(cat "$package_json")"
-    if ! echo "$_tmp" | sed '/"main"/ s#"[^"]*",$#"./app_launcher/'"$jsfile_name"'",#' | $sudo_cmd tee "$package_json" >/dev/null; then
+    if ! echo "$_tmp" | sed '/"main"/ s#"[^"]*",$#"./app_launcher/'"$jsfile_name"'",#' | sudo tee "$package_json" >/dev/null; then
         log_error "修改失败：$package_json"; return 1
     fi
     log_info "修改文件 main 字段成功：'./app_launcher/$jsfile_name'"

--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,17 @@ function elevate_permissions() {
             log_info "请输入您的密码以提升权限："
             sudo -v || { log_error "提权失败，请重试或添加 '-k' 参数以跳过提权，退出"; return 1; }
             sudo_cmd="sudo" ;;
-        macos)  sudo_cmd="" ;;
+        macos)  
+            testfile="/Applications/test_permission_file"
+            if touch "$testfile" 2>/dev/null; then
+              log_info "终端具有对 /Applications 的管理权限。"
+              rm "$testfile"              
+            else
+              log_info "终端没有对 /Applications 的管理权限。"
+              log_info "推荐赋予终端 完全磁盘访问权限 App管理权限。"
+            fi
+          
+            sudo_cmd="" ;;
     esac
 }
 

--- a/install.sh
+++ b/install.sh
@@ -399,7 +399,11 @@ function patch_macos_qq_hot_update() {
     log_info "尝试处理 QQ 热更新"
     for _tmp in "${qq_update_dir[@]}"; do
         qq_res_path=$(get_qq_resources_path "$_tmp") || { log_info "无热更新."; continue; }
-        patch_resources
+#       patch_resources
+        log_error "检测到版本存在热更新"
+        log_error "目前 LiteLoaderQQNT 无法对 macOS 上热更新处理"
+        log_error "请更新到手动最新版本或者使用 App Store 版本QQ"
+        # 后续可能临时在脚本添加自动更新为最新版本，再重新安装LL作为过渡
     done
     return 0 # TODO 无论是否成功都返回 true，待优化？
 }

--- a/install_windows.py
+++ b/install_windows.py
@@ -33,7 +33,6 @@ def get_github_proxy_urls():
         "https://gh.h233.eu.org",
         "https://gh.ddlc.top",
         "https://slink.ltd",
-        "https://gh.con.sh",
         "https://cors.isteed.cc",
         "https://hub.gitmirror.com",
         "https://sciproxy.com",


### PR DESCRIPTION
This pull request includes several changes to the `install.sh` script and a small update to `install_windows.py`. The most significant changes involve enhancing permission checks on macOS, modifying the handling of proxy URLs, and updating the patching process for resources and macOS QQ hot updates.

Enhancements to permission checks on macOS:

* [`install.sh`](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL89-R99): Added a check to determine if the terminal has management permissions for the `/Applications` directory and provided recommendations for granting full disk access if needed.

Modifications to proxy URLs:

* [`install.sh`](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL111): Removed the proxy URL `https://gh.con.sh` from the list of GitHub download proxies.
* [`install_windows.py`](diffhunk://#diff-e5f58f1e55055da4c0ce8a376bd823bc81670fed49251a4dd38afd42d4b3391bL36): Removed the proxy URL `https://gh.con.sh` from the list of GitHub proxy URLs.

Updates to the patching process for resources:

* [`install.sh`](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL364-R373): Changed the command for writing to `*.js` files and modifying the `main` field in `package.json` to use `sudo` directly instead of a variable. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL364-R373) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL374-R383)

Updates to macOS QQ hot updates:

* [`install.sh`](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL387-R400): Disabled the `patch_resources` function for macOS QQ hot updates and added error messages to inform users that LiteLoaderQQNT cannot handle hot updates on macOS.

## 摘要由 Sourcery

通过为 macOS 添加增强的权限检查、删除过时的代理 URL 以及更新资源和 macOS QQ 热更新的补丁过程来改进安装脚本。

增强功能：
- 优化安装过程中代理 URL 的处理。

构建：
- 为 macOS 的 `/Applications` 目录添加权限检查。
- 删除 `https://gh.con.sh` 代理 URL。
- 更新资源补丁以直接使用 `sudo`。
- 禁用 macOS QQ 热更新的资源补丁，并添加错误消息以通知用户热更新的不兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the installation script by adding enhanced permission checks for macOS, removing an outdated proxy URL, and updating the patching process for resources and macOS QQ hot updates.

Enhancements:
- Refine the handling of proxy URLs during installation.

Build:
- Add permission checks for the `/Applications` directory on macOS.
- Remove the `https://gh.con.sh` proxy URL.
- Update resource patching to use `sudo` directly.
- Disable resource patching for macOS QQ hot updates and add error messages informing users about incompatibility with hot updates.

</details>