### PR TITLE
refactor: get_working_proxy

### DIFF
--- a/install_windows.py
+++ b/install_windows.py
@@ -128,11 +128,10 @@ def get_document_path() -> str:
     return path
 
 
-def can_connect(url, timeout=2):
+def can_connect(url: str, timeout: float = 2) -> bool:
     try:
-        response = requests.head(url, timeout=timeout)
-        return response.status_code >= 200 and response.status_code < 400
-    except requests.exceptions.RequestException:
+        return requests.head(url, timeout=timeout).ok
+    except requests.RequestException:
         return False
 
 
@@ -461,28 +460,26 @@ def install_plugin_store(file_path):
         print(f"安装插件商店发生错误: {e}\n请尝试手动安装")
 
 
-def check_proxy(proxy):
-    try:
-        proxy_url = f"{proxy}/https://github.com"
-        response = requests.head(proxy_url, timeout=5)
-        if response.ok:
-            return proxy
-    except requests.exceptions.RequestException:
-        pass
-    return None
+def check_proxy(url: str, timeout: float = 5) -> tuple[str, bool]:
+    return url, can_connect(
+        f"{url}/https://github.com/Mzdyl/LiteLoaderQQNT_Install/archive/refs/heads/main.zip",
+        timeout,
+    )
 
 
-def get_working_proxy():
+def get_working_proxy() -> str:
     proxies = get_github_proxy_urls()
-    with ThreadPoolExecutor(max_workers=len(proxies)) as executor:
-        future_to_proxy = {
-            executor.submit(check_proxy, proxy): proxy for proxy in proxies
-        }
-        for future in as_completed(future_to_proxy):
-            result = future.result()
-            if result is not None:
-                return result
-    return None
+    executor = ThreadPoolExecutor()
+    try:
+        for future in as_completed(
+            [executor.submit(check_proxy, proxy) for proxy in proxies]
+        ):
+            proxy, result = future.result()
+            if result:
+                return proxy
+        return ""
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
 
 
 def get_download_url(url: str) -> str:


### PR DESCRIPTION
## Sourcery 总结

重构了用于检查代理连接性的辅助函数，改进了类型提示，精简了逻辑，并实现了更安全的执行器关闭。

增强功能：
- 在 `can_connect` 中添加类型注解并统一异常处理
- 简化 `can_connect` 以使用 `response.ok`
- 更改 `check_proxy` 以返回 URL 和针对 ZIP 归档文件的连接结果的元组
- 重构 `get_working_proxy` 以内联方式提交 futures，正确关闭执行器，并在没有可用代理时返回空字符串

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor helper functions for checking proxy connectivity with improved type hints, streamlined logic, and safer executor shutdown.

Enhancements:
- Add type annotations and unify exception handling in can_connect
- Simplify can_connect to use response.ok
- Change check_proxy to return a tuple of URL and connectivity result against the ZIP archive
- Refactor get_working_proxy to submit futures inline, properly shutdown the executor, and return an empty string when no proxy works

</details>